### PR TITLE
Fix startup issues when pygments is already detected

### DIFF
--- a/code_highlight_addon/code_highlight_addon.py
+++ b/code_highlight_addon/code_highlight_addon.py
@@ -191,7 +191,10 @@ def addons_folder(): return mw.pm.addonFolder()
 
 #  Tell Python where to look here for our stripped down
 # version of the Pygments package: 
-sys.path.insert(0, os.path.join(addons_folder(), "code_highlight_addon"))
+try:
+    __import__('pygments')
+except ImportError:
+    sys.path.insert(0, os.path.join(addons_folder(), "code_highlight_addon"))
 
 # Choose default language from the last to be used
 #lang_file_path = os.path.join(addons_folder(), "code_highlight_addon", "lang.txt")


### PR DESCRIPTION
This uses the system version of pyments over the bundled version and fixes the errors when starting Anki such as

```
 /home/user/Anki/addons/code_highlight_addon/pygments/plugin.py:39:        
 UserWarning: Module pygments was already imported from /home/user/Anki/addons/code_highlight_addon/pygments/__init__.pyc, but /usr/lib/python2.7/dist-packages is being added to sys.path
 import pkg_resources
```
